### PR TITLE
Decimal places are optional in float with exponent

### DIFF
--- a/htoml.cabal
+++ b/htoml.cabal
@@ -80,6 +80,7 @@ test-suite Tests
   type:                   exitcode-stdio-1.0
   default-language:        Haskell2010
   build-depends:          base
+                        , aeson
                         , parsec
                         , containers
                         , bytestring

--- a/src/Text/Toml/Parser.hs
+++ b/src/Text/Toml/Parser.hs
@@ -195,9 +195,8 @@ datetime = do
 -- | Attoparsec 'double' parses scientific "e" notation; reimplement according to Toml spec.
 float :: Parser TValue
 float = VFloat <$> do
-    n <- intStr
-    _ <- char '.'
-    d <- uintStr
+    n <- intStr <* lookAhead (satisfy (\c -> c == '.' || c == 'e' || c == 'E'))
+    d <- try (satisfy (== '.') *> uintStr) <|> return "0"
     e <- try (satisfy (\c -> c == 'e' || c == 'E') *> intStr) <|> return "0"
     return . read . L.concat $ [n, ".", d, "e", e]
   where


### PR DESCRIPTION
Still need to ensure that valid ints don't parse though
#2 